### PR TITLE
feat(unitok-web/back-end): add ticket transaction history to support ticket ledger view

### DIFF
--- a/apps/unitok-web/prisma/migrations/20260122112820/migration.sql
+++ b/apps/unitok-web/prisma/migrations/20260122112820/migration.sql
@@ -1,0 +1,36 @@
+/*
+  Warnings:
+
+  - The values [CHECK,MIXED] on the enum `AttendanceType` will be removed. If these variants are still used in the database, this will fail.
+  - Added the required column `teamWork` to the `Review` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "TeamWorkLevel" AS ENUM ('ALWAYS', 'OFTEN', 'RARELY');
+
+-- AlterEnum
+BEGIN;
+CREATE TYPE "AttendanceType_new" AS ENUM ('CALL', 'ONLINE', 'MIX', 'NONE');
+ALTER TABLE "Review" ALTER COLUMN "attendance" TYPE "AttendanceType_new" USING ("attendance"::text::"AttendanceType_new");
+ALTER TYPE "AttendanceType" RENAME TO "AttendanceType_old";
+ALTER TYPE "AttendanceType_new" RENAME TO "AttendanceType";
+DROP TYPE "public"."AttendanceType_old";
+COMMIT;
+
+-- AlterEnum
+-- This migration adds more than one value to an enum.
+-- With PostgreSQL versions 11 and earlier, this is not possible
+-- in a single migration. This can be worked around by creating
+-- multiple migrations, each migration adding only one value to
+-- the enum.
+
+
+ALTER TYPE "ExamFormat" ADD VALUE 'ONLINE';
+ALTER TYPE "ExamFormat" ADD VALUE 'PAPER';
+ALTER TYPE "ExamFormat" ADD VALUE 'SPEAK';
+
+-- AlterTable
+ALTER TABLE "ExamInfo" ALTER COLUMN "costPoints" SET DEFAULT 10;
+
+-- AlterTable
+ALTER TABLE "Review" ADD COLUMN     "teamWork" "TeamWorkLevel" NOT NULL;

--- a/apps/unitok-web/prisma/migrations/20260122115247/migration.sql
+++ b/apps/unitok-web/prisma/migrations/20260122115247/migration.sql
@@ -1,0 +1,72 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `costPoints` on the `ExamInfo` table. All the data in the column will be lost.
+  - You are about to drop the column `professorId` on the `Review` table. All the data in the column will be lost.
+  - You are about to drop the column `points` on the `User` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[userId,courseId]` on the table `ExamInfo` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[userId,courseId]` on the table `Review` will be added. If there are existing duplicate values, this will fail.
+  - Made the column `courseId` on table `Review` required. This step will fail if there are existing NULL values in that column.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Review" DROP CONSTRAINT "Review_courseId_fkey";
+
+-- DropForeignKey
+ALTER TABLE "Review" DROP CONSTRAINT "Review_professorId_fkey";
+
+-- DropIndex
+DROP INDEX "Review_professorId_idx";
+
+-- DropIndex
+DROP INDEX "Review_userId_professorId_courseId_key";
+
+-- AlterTable
+ALTER TABLE "ExamInfo" DROP COLUMN "costPoints",
+ADD COLUMN     "costTickets" INTEGER NOT NULL DEFAULT 10;
+
+-- AlterTable
+ALTER TABLE "Review" DROP COLUMN "professorId",
+ALTER COLUMN "courseId" SET NOT NULL;
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "points",
+ADD COLUMN     "tickets" INTEGER NOT NULL DEFAULT 0;
+
+-- CreateTable
+CREATE TABLE "Like" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "reviewId" TEXT,
+    "examInfoId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Like_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Like_userId_reviewId_key" ON "Like"("userId", "reviewId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Like_userId_examInfoId_key" ON "Like"("userId", "examInfoId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ExamInfo_userId_courseId_key" ON "ExamInfo"("userId", "courseId");
+
+-- CreateIndex
+CREATE INDEX "Review_courseId_idx" ON "Review"("courseId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Review_userId_courseId_key" ON "Review"("userId", "courseId");
+
+-- AddForeignKey
+ALTER TABLE "Review" ADD CONSTRAINT "Review_courseId_fkey" FOREIGN KEY ("courseId") REFERENCES "Course"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_reviewId_fkey" FOREIGN KEY ("reviewId") REFERENCES "Review"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Like" ADD CONSTRAINT "Like_examInfoId_fkey" FOREIGN KEY ("examInfoId") REFERENCES "ExamInfo"("id") ON DELETE SET NULL ON UPDATE CASCADE;

--- a/apps/unitok-web/prisma/migrations/20260122122551_add_ticket_model_and_enums/migration.sql
+++ b/apps/unitok-web/prisma/migrations/20260122122551_add_ticket_model_and_enums/migration.sql
@@ -1,0 +1,21 @@
+-- CreateEnum
+CREATE TYPE "TicketAction" AS ENUM ('REVIEW_CREATED', 'EXAM_INFO_CREATED', 'EXAM_INFO_VIEWED', 'REVIEW_LIKED', 'EXAM_INFO_LIKED');
+
+-- CreateTable
+CREATE TABLE "TicketTransaction" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "action" "TicketAction" NOT NULL,
+    "reviewId" TEXT,
+    "examInfoId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TicketTransaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "TicketTransaction_userId_createdAt_idx" ON "TicketTransaction"("userId", "createdAt");
+
+-- AddForeignKey
+ALTER TABLE "TicketTransaction" ADD CONSTRAINT "TicketTransaction_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/apps/unitok-web/prisma/schema.prisma
+++ b/apps/unitok-web/prisma/schema.prisma
@@ -10,15 +10,34 @@ datasource db {
 model User {
   id            String   @id @default(cuid())
   nickname      String?
-  points        Int      @default(0)
+  tickets       Int      @default(0)
 
   universityId  String
   university    University @relation(fields: [universityId], references: [id])
 
   reviews       Review[]
   examInfos     ExamInfo[]
+  likes         Like[]
+  ticketLogs    TicketTransaction[]
 
   createdAt     DateTime @default(now())
+}
+
+model TicketTransaction {
+  id          String   @id @default(cuid())
+
+  userId      String
+  user        User     @relation(fields: [userId], references: [id])
+
+  amount      Int
+  action      TicketAction
+
+  reviewId    String?
+  examInfoId  String?
+
+  createdAt   DateTime @default(now())
+
+  @@index([userId, createdAt])
 }
 
 model University {
@@ -52,7 +71,6 @@ model Professor {
   department    Department @relation(fields: [departmentId], references: [id])
 
   courses       Course[]
-  reviews       Review[]
 
   createdAt     DateTime @default(now())
 }
@@ -76,11 +94,8 @@ model Review {
   userId        String
   user          User     @relation(fields: [userId], references: [id])
 
-  professorId   String
-  professor     Professor @relation(fields: [professorId], references: [id])
-
-  courseId      String?
-  course        Course?  @relation(fields: [courseId], references: [id])
+  courseId      String
+  course        Course   @relation(fields: [courseId], references: [id])
 
   rating        Int
   comment       String?
@@ -90,13 +105,16 @@ model Review {
 
   workload      WorkloadLevel
   difficulty    DifficultyLevel
+  teamWork      TeamWorkLevel
   attendance    AttendanceType
   examCount     ExamCount
 
+  likes         Like[]
+
   createdAt     DateTime @default(now())
 
-  @@unique([userId, professorId, courseId])
-  @@index([professorId])
+  @@unique([userId, courseId])
+  @@index([courseId])
 }
 
 model ExamInfo {
@@ -117,13 +135,15 @@ model ExamInfo {
   preparationTip   String?
   recommendation   String?
 
-  costPoints       Int      @default(1)
+  costTickets      Int      @default(10)
 
   formats          ExamInfoFormat[]
   questions        ExamQuestion[]
+  likes            Like[]
 
   createdAt        DateTime @default(now())
 
+  @@unique([userId, courseId])
   @@index([courseId])
 }
 
@@ -143,7 +163,32 @@ model ExamQuestion {
   text        String
 }
 
-// change the enums and point costs later
+model Like {
+  id          String   @id @default(cuid())
+
+  userId      String
+  user        User     @relation(fields: [userId], references: [id])
+
+  reviewId    String?
+  review      Review?   @relation(fields: [reviewId], references: [id])
+
+  examInfoId  String?
+  examInfo    ExamInfo? @relation(fields: [examInfoId], references: [id])
+
+  createdAt   DateTime @default(now())
+
+  @@unique([userId, reviewId])
+  @@unique([userId, examInfoId])
+}
+
+enum TicketAction {
+  REVIEW_CREATED
+  EXAM_INFO_CREATED
+  EXAM_INFO_VIEWED
+  REVIEW_LIKED
+  EXAM_INFO_LIKED
+}
+
 enum Semester {
   SPRING
   SUMMER
@@ -163,10 +208,17 @@ enum DifficultyLevel {
   HARD
 }
 
+enum TeamWorkLevel {
+  ALWAYS
+  OFTEN
+  RARELY
+}
+
 enum AttendanceType {
+  CALL
+  ONLINE
+  MIX
   NONE
-  CHECK
-  MIXED
 }
 
 enum ExamCount {
@@ -183,6 +235,9 @@ enum ExamType {
 }
 
 enum ExamFormat {
+  ONLINE
+  PAPER
+  SPEAK
   OBJECTIVE
   ESSAY
   CODING


### PR DESCRIPTION
**What**

* Added a `TicketTransaction` model to track ticket earn and spend events.
* Linked ticket transactions to users and optionally to reviews or exam infos.
* Updated the user schema to expose ticket history alongside the current ticket balance.

**Why**

* The ticket history screen requires per-action ticket changes, timestamps, and descriptions.
* A single `tickets` counter is insufficient to reliably render this data or debug ticket changes.
* Storing an append-only ticket transaction log enables accurate history views while keeping reads fast.

**How**

* Introduced a new `TicketTransaction` table with minimal fields (amount, action, timestamps).
* Added a one-to-many relation between `User` and `TicketTransaction`.
* Kept existing ticket update logic intact while ensuring all earn/spend actions also write a transaction record.

**How to test**

1. Run database migrations:
   ```bash
   yarn prisma migrate dev
   ```
2. Generate the Prisma client:
   ```bash
   yarn prisma generate
   ```
3. Trigger ticket actions in the app (add review, view exam info, like content).
4. Verify the ticket balance updates correctly and the ticket history list renders expected entries.

**Notes**

* This change is additive and does not introduce breaking changes.
* The transaction table is intentionally minimal to avoid over-engineering while supporting current UI needs.

Closes #150 
