### PR TITLE
add Clerk authentication to GraphQL context

### DIFF
--- a/apps/doozy/app/api/graphql/context.ts
+++ b/apps/doozy/app/api/graphql/context.ts
@@ -1,5 +1,9 @@
 import { auth } from '@clerk/nextjs/server';
 
 export const createContext = async () => {
-  const { userId } = await auth;
+  const { userId } = await auth();
+
+  return { userId };
 };
+
+export type GraphQLContext = Awaited<ReturnType<typeof createContext>>;

--- a/apps/doozy/app/api/graphql/resolvers/query.resolver.ts
+++ b/apps/doozy/app/api/graphql/resolvers/query.resolver.ts
@@ -1,3 +1,9 @@
 export const queryResolvers = {
-  health: () => 'ok',
+  health: (
+    _parent: unknown,
+    _args: unknown,
+    ctx: { userId: string | null },
+  ) => {
+    return ctx.userId ? 'authenticated' : 'anonymous';
+  },
 };

--- a/apps/doozy/app/api/route.ts
+++ b/apps/doozy/app/api/route.ts
@@ -1,6 +1,9 @@
 import { server } from './graphql';
 import { startServerAndCreateNextHandler } from '@as-integrations/next';
+import { createContext } from './graphql/context';
 
-const handler = startServerAndCreateNextHandler(server);
+const handler = startServerAndCreateNextHandler(server, {
+  context: async () => createContext(),
+});
 
 export { handler as GET, handler as POST };

--- a/apps/doozy/app/layout.tsx
+++ b/apps/doozy/app/layout.tsx
@@ -1,4 +1,5 @@
 import './global.css';
+import { ClerkProvider } from '@clerk/nextjs';
 
 export const metadata = {
   title: 'Welcome to doozy',
@@ -11,8 +12,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body>{children}</body>
-    </html>
+    <ClerkProvider>
+      <html lang="en">
+        <body>{children}</body>
+      </html>
+    </ClerkProvider>
   );
 }


### PR DESCRIPTION
- Integrate Clerk into Next.js app router
- Add Clerk middleware for server-side auth
- Inject authenticated userId into GraphQL context
- No business logic or access control yet
